### PR TITLE
Fix punycode warning

### DIFF
--- a/vendor/package-json/index.js
+++ b/vendor/package-json/index.js
@@ -45,7 +45,7 @@ const packageJson = async (packageName, options) => {
 
 	let data;
 	try {
-		data = await fetch(packageUrl, { keepAlive: true, headers }).then(r => r.json());
+		data = await fetch(packageUrl, { keepAlive: true, keepalive: true, headers }).then(r => r.json());
 	} catch (error) {
 		if (error.response.statusCode === 404) {
 			throw new PackageNotFoundError(packageName);

--- a/vendor/package-json/index.js
+++ b/vendor/package-json/index.js
@@ -1,5 +1,7 @@
 'use strict';
-require('isomorphic-fetch');
+if (!fetch) {
+	require('isomorphic-fetch');
+}
 const registryUrl = require('registry-url');
 const registryAuthToken = require('registry-auth-token');
 const semver = require('semver');


### PR DESCRIPTION
When executing in >= Node.js 21, a warning is shown:
```
(node:73064) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

Chasing down the rabbit hole:
update-notifier-cjs -> isomorphic-fetch (v3.0.0) -> node-fetch -> whatwg-url -> punycode -> whatwg-url -> tr46 -> punycode

The problem with bumping isomorphic-fetch above 3 is that it moved to MJS, which then defeats the purpose of this CJS fork.

This hacky PR makes the require of isomorphic-fetch conditional on global fetch not being available, which should then mean the bad code path never gets executed past Node.js 18.

I've also added a dupe of the `keepAlive` flag to fetch because it seems to be cased different in `fetch` proper.